### PR TITLE
Updating how CsvProcessor checks for BOM at the beginning of a file

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filevalidationservice/parser/CsvProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/filevalidationservice/parser/CsvProcessor.java
@@ -71,6 +71,7 @@ public class CsvProcessor {
 
             while (it.hasNext()) {
                 var csvRecord = it.next();
+                LOGGER.debug(String.format("Processing record: %s", csvRecord.toString()));
 
                 if (!NUMBER_OF_COLUMNS.equals(csvRecord.size())) {
                     throw new CSVDataValidationException(String.format("Incorrect number of columns. Received: %s Expected: %s", csvRecord.size(), NUMBER_OF_COLUMNS ));

--- a/src/main/java/uk/gov/companieshouse/filevalidationservice/parser/CsvProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/filevalidationservice/parser/CsvProcessor.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -11,7 +12,6 @@ import java.util.Locale;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.io.input.BOMInputStream;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.filevalidationservice.exception.CSVDataValidationException;
 import uk.gov.companieshouse.filevalidationservice.validation.CsvRecordValidator;
@@ -43,7 +43,17 @@ public class CsvProcessor {
 
     public void parseRecords(byte[] bytesToParse) {
         int currentRow = 1;
-        try (var reader = new InputStreamReader(BOMInputStream.builder().setInputStream(new ByteArrayInputStream(bytesToParse)).get(), StandardCharsets.UTF_8)) {
+
+        // Check for UTF-8 BOM (0xEF,0xBB,0xBF)
+        if (bytesToParse.length >= 3 &&
+            (bytesToParse[0] & 0xFF) == 0xEF &&
+            (bytesToParse[1] & 0xFF) == 0xBB &&
+            (bytesToParse[2] & 0xFF) == 0xBF) {
+            // Strip BOM
+            bytesToParse = Arrays.copyOfRange(bytesToParse, 3, bytesToParse.length);
+        }
+
+        try (var reader = new InputStreamReader(new ByteArrayInputStream(bytesToParse), StandardCharsets.UTF_8)) {
 
             CSVParser parser = CSVFormat.DEFAULT
                     .builder()

--- a/src/test/java/uk/gov/companieshouse/filevalidationservice/parser/CsvProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/filevalidationservice/parser/CsvProcessorTest.java
@@ -46,6 +46,18 @@ class CsvProcessorTest {
         assertDoesNotThrow(() -> csvProcessor.parseRecords(bytes));
     }
 
+    @Test
+    void validRecordsMustParseWithBOM() throws IOException {
+        File file = new File("src/test/resources/good_multiple_records.csv");
+        byte[] bytes = FileUtils.readFileToByteArray(file);
+        byte[] bomBytes = new byte[] {(byte)0xEF, (byte)0xBB, (byte)0xBF};
+
+        byte[] combinedBytes = new byte[bomBytes.length + bytes.length];
+        System.arraycopy(bomBytes, 0, combinedBytes, 0, bomBytes.length);
+        System.arraycopy(bytes, 0, combinedBytes, bomBytes.length, bytes.length);
+        assertDoesNotThrow(() -> csvProcessor.parseRecords(combinedBytes));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             "src/test/resources/emptyCsv.csv",


### PR DESCRIPTION
__Short description outlining key changes/additions__

Updating how the csv processor checks for BOM characters. It no longer used BOMInputStream, it now checks the raw bytes for the BOM and if present removes them.

__JIRA Ticket Number__

IDVA5-2203

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__