### PR TITLE
asm-2191: Uplifted file-validation-api to use Spring Boot 4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,20 +14,28 @@
 	<description>ACSP workstream</description>
 	<properties>
 		<main.class>uk.gov.companieshouse.filevalidationservice.FileValidationApplication</main.class>
-		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-		<maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-		<structured-logging.version>3.0.10</structured-logging.version>
-		<rest-service-common-library-version>2.0.2</rest-service-common-library-version>
+		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+		<maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+		<java.version>21</java.version>
+		<structured-logging.version>3.0.55</structured-logging.version> <!--DONE-->
+		<rest-service-common-library-version>2.0.11</rest-service-common-library-version>
 		<private-api-sdk-java.version>4.0.248</private-api-sdk-java.version>
-		<api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
+		<api-sdk-manager-java-library.version>3.0.22</api-sdk-manager-java-library.version>
 		<api-security-java.version>2.0.7</api-security-java.version>
-		<spring-boot-dependencies.version>3.4.4</spring-boot-dependencies.version>
-		<spring-boot-maven-plugin.version>3.4.4</spring-boot-maven-plugin.version>
+		<spring-boot.version>4.0.6</spring-boot.version>
+		<spring-boot-dependencies.version>${spring-boot.version}</spring-boot-dependencies.version>
+		<spring-boot-maven-plugin.version>${spring-boot.version}</spring-boot-maven-plugin.version>
 		<junit.version>4.13.2</junit.version>
 		<junit-jupiter.version>1.20.6</junit-jupiter.version>
-		<api-helper-java.version>3.0.1</api-helper-java.version>
+		<api-helper-java.version>3.0.4</api-helper-java.version>
 		<flapdoodle.version>4.16.1</flapdoodle.version>
 		<commons-csv.version>1.12.0</commons-csv.version>
+		<awssdk.version>2.30.21</awssdk.version>
+		<shedlock-spring.version>6.0.2</shedlock-spring.version>
+		<jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
+		<jib-source-image.name>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21</jib-source-image.name>
+		<jib-target-image.name>416670754337.dkr.ecr.eu-west-2.amazonaws.com/file-validation-api</jib-target-image.name>
+		<tika-core.version>3.3.0</tika-core.version>
 
 		<sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
 		<sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
@@ -37,6 +45,7 @@
 		<sonar.projectKey>uk.gov.companieshouse:file-validation-api</sonar.projectKey>
 		<sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -48,6 +57,7 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -58,33 +68,27 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
 			<version>${commons-csv.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>uk.gov.companieshouse</groupId>
 			<artifactId>structured-logging</artifactId>
 			<version>${structured-logging.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-simple</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>uk.gov.companieshouse</groupId>
 			<artifactId>rest-service-common-library</artifactId>
 			<version>${rest-service-common-library-version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>uk.gov.companieshouse</groupId>
@@ -109,41 +113,35 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
-			<version>2.30.21</version>
-			<exclusions>
-				<exclusion>
-					<groupId>io.netty</groupId>
-					<artifactId>netty-common</artifactId>
-				</exclusion>
-				<!--CVE-2025-24970-->
-				<exclusion>
-					<groupId>io.netty</groupId>
-					<artifactId>netty-handler</artifactId>
-				</exclusion>
-			</exclusions>
+			<version>${awssdk.version}</version>
 		</dependency>
 		<!-- ShedLock Core -->
 		<dependency>
 			<groupId>net.javacrumbs.shedlock</groupId>
 			<artifactId>shedlock-spring</artifactId>
-			<version>6.0.2</version>
+			<version>${shedlock-spring.version}</version>
 		</dependency>
 		<!-- ShedLock MongoDB Provider -->
 		<dependency>
 			<groupId>net.javacrumbs.shedlock</groupId>
 			<artifactId>shedlock-provider-mongo</artifactId>
-			<version>6.0.2</version>
+			<version>${shedlock-spring.version}</version>
 		</dependency>
 		<!-- Tika -->
 		<dependency>
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
-			<version>3.0.0</version>
+			<version>${tika-core.version}</version>
 		</dependency>
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -180,13 +178,13 @@
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
-				<version>3.4.0</version>
+				<version>${jib-maven-plugin.version}</version>
 				<configuration>
 					<from>
-						<image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21</image>
+						<image>${jib-source-image.name}</image>
 					</from>
 					<to>
-						<image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/file-validation-api</image>
+						<image>${jib-target-image.name}</image>
 					</to>
 					<container>
 						<expandClasspathDependencies>true</expandClasspathDependencies>
@@ -207,8 +205,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
-					<source>21</source>
-					<target>21</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<parameters>true</parameters>
 				</configuration>
 			</plugin>

--- a/src/test/java/uk/gov/companieshouse/filevalidationservice/controllers/ControllerAdviceTest.java
+++ b/src/test/java/uk/gov/companieshouse/filevalidationservice/controllers/ControllerAdviceTest.java
@@ -1,5 +1,9 @@
 package uk.gov.companieshouse.filevalidationservice.controllers;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.apache.tika.Tika;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +18,6 @@ import uk.gov.companieshouse.filevalidationservice.configuration.InterceptorConf
 import uk.gov.companieshouse.filevalidationservice.exception.InternalServerErrorRuntimeException;
 import uk.gov.companieshouse.filevalidationservice.exception.NotFoundRuntimeException;
 import uk.gov.companieshouse.filevalidationservice.service.FileTransferService;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CsvValidationController.class)
 class ControllerAdviceTest {

--- a/src/test/java/uk/gov/companieshouse/filevalidationservice/controllers/ControllerAdviceTest.java
+++ b/src/test/java/uk/gov/companieshouse/filevalidationservice/controllers/ControllerAdviceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;


### PR DESCRIPTION
__Short description outlining key changes/additions__

NOT TO BE MERGED INTO MAIN TILL POST MONGO 8 UPGRADE

* Uplifted Spring Boot version to 4.0.6
* Uplifted CH library versions (other than sdk-java)
* Ensured all versions / image names now represented by properties to make it easier to amend in one place.
* Removed exclusions in pom file, mvn clean install reporting no erors and depcheck giving clean bill of health.
* Added spring-boot-starter-webmvc-test dependency, Spring Boot 4 splitting functionality out.
* Amended ControllerAdviceTest import due to WebMvcTest being in a different package for Spring Boot 4.

__JIRA Ticket Number__

[ASM-2192](https://companieshouse.atlassian.net/browse/ASM-2192)

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Breaking change
* [X] Infrastructure change

### Pull request checklist

* [] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[ASM-2192]: https://companieshouse.atlassian.net/browse/ASM-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ